### PR TITLE
support unmodified kinematics

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -90,7 +90,7 @@ class BedMesh:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.last_position = [0., 0., 0., 0.]
+        self.last_position = [0., 0., 0., 0., 0., 0., 0.]
         self.bmc = BedMeshCalibrate(config, self)
         self.z_mesh = None
         self.toolhead = None
@@ -180,7 +180,7 @@ class BedMesh:
             self.last_position[2] -= self.fade_target
         else:
             # return current position minus the current z-adjustment
-            x, y, z, e = self.toolhead.get_position()
+            x, y, z, a, b, c, e = self.toolhead.get_position()
             max_adj = self.z_mesh.calc_z(x, y)
             factor = 1.
             z_adj = max_adj - self.fade_target
@@ -195,19 +195,19 @@ class BedMesh:
                           (self.fade_dist - z_adj))
                 factor = constrain(factor, 0., 1.)
             final_z_adj = factor * z_adj + self.fade_target
-            self.last_position[:] = [x, y, z - final_z_adj, e]
+            self.last_position[:] = [x, y, z - final_z_adj, a, b, c, e]
         return list(self.last_position)
     def move(self, newpos, speed):
         factor = self.get_z_factor(newpos[2])
         if self.z_mesh is None or not factor:
             # No mesh calibrated, or mesh leveling phased out.
-            x, y, z, e = newpos
+            x, y, z, a, b, c, e = newpos
             if self.log_fade_complete:
                 self.log_fade_complete = False
                 logging.info(
                     "bed_mesh fade complete: Current Z: %.4f fade_target: %.4f "
                     % (z, self.fade_target))
-            self.toolhead.move([x, y, z + self.fade_target, e], speed)
+            self.toolhead.move([x, y, z + self.fade_target, a, b, c, e], speed)
         else:
             self.splitter.build_move(self.last_position, newpos, factor)
             while not self.splitter.traverse_complete:

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
+import support_6axes
 
 HOMING_START_DELAY = 0.001
 ENDSTOP_SAMPLE_TIME = .000015
@@ -67,6 +68,7 @@ class HomingMove:
         return list(kin.calc_position(kin_spos))[:6] + thpos[6:]
     def homing_move(self, movepos, speed, probe_pos=False,
                     triggered=True, check_triggered=True):
+        movepos = support_6axes.Axes.extend(movepos)
         # Notify start of homing/probing move
         self.printer.send_event("homing:homing_move_begin", self)
         # Note start location
@@ -127,6 +129,7 @@ class HomingMove:
                 halt_kin_spos = {s.get_name(): s.get_commanded_position()
                                  for s in kin.get_steppers()}
                 haltpos = self.calc_toolhead_pos(halt_kin_spos, over_steps)
+        haltpos = support_6axes.Axes.extend(haltpos)
         self.toolhead.set_position(haltpos)
         # Signal homing/probing move complete
         try:
@@ -171,6 +174,8 @@ class Homing:
     def set_homed_position(self, pos):
         self.toolhead.set_position(self._fill_coord(pos))
     def home_rails(self, rails, forcepos, movepos):
+        forcepos = support_6axes.Axes.extend(forcepos)
+        movepos = support_6axes.Axes.extend(movepos)
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
         # Alter kinematics class to think printer is at forcepos

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -9,6 +9,7 @@ class CommandError(Exception):
     pass
 
 Coord = collections.namedtuple('Coord', ('x', 'y', 'z', 'a', 'b', 'c', 'e'))
+Coord.__new__.__defaults__ = (0., 0., 0., 0., 0., 0., 0.)
 
 class GCodeCommand:
     error = CommandError

--- a/klippy/support_6axes.py
+++ b/klippy/support_6axes.py
@@ -1,0 +1,42 @@
+# Code for support 6 axes
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+ 
+class Axes:
+    @classmethod
+    def extend(self, pos):
+        if len(pos) > 4:
+            return pos
+
+        if isinstance(pos, tuple):
+            if len(pos) == 4:
+                return (pos[0], pos[1], pos[2], 0., 0., 0., pos[3])
+            else:
+                return (pos[0], pos[1], pos[2], 0., 0., 0.)
+
+        if len(pos) == 4:
+            pos.extend([0.,0.,pos[3]])
+            pos[3] = 0.
+        else:
+            pos.extend([0., 0., 0.])
+
+        return pos
+
+    @classmethod
+    def shrink(self, pos):
+        if len(pos) <= 4:
+            return pos
+        
+        if isinstance(pos, tuple):
+            if len(pos) == 7:
+                return (pos[0], pos[1], pos[2], pos[6])
+            else:
+                return (pos[0], pos[1], pos[2])
+
+        e = pos.pop()
+        pos.pop()
+        pos.pop()
+        if len(pos) == 4:
+            pos[3] = e
+
+        return pos

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging, importlib
 import mcu, chelper, kinematics.extruder
+import support_6axes
 
 # Common suffixes: _d is distance (in mm), _v is velocity (in
 #   mm/second), _v2 is velocity squared (mm^2/s^2), _t is time (in
@@ -13,6 +14,8 @@ import mcu, chelper, kinematics.extruder
 # Class to track each move request
 class Move:
     def __init__(self, toolhead, start_pos, end_pos, speed):
+        start_pos = support_6axes.Axes.extend(start_pos)
+        end_pos = support_6axes.Axes.extend(end_pos)
         self.toolhead = toolhead
         self.start_pos = tuple(start_pos)
         self.end_pos = tuple(end_pos)
@@ -20,7 +23,7 @@ class Move:
         self.timing_callbacks = []
         velocity = min(speed, toolhead.max_velocity)
         self.is_kinematic_move = True
-        self.axes_d = axes_d = [end_pos[i] - start_pos[i] for i in (0, 1, 2, 3, 4, 5, 6)]
+        self.axes_d = axes_d = [end_pos[i] - start_pos[i] for i in range(7)]
         self.move_d = move_d = math.sqrt(sum([d*d for d in axes_d[:6]]))
         if move_d < .000000001:
             # Extrude only move


### PR DESCRIPTION
3軸のkinematics/corexy.pyを無修正で動かせるように6軸コア側に最小限の変更を試みました。
まだバグがあり不完全ですが、現状の変更内容のご報告としてプルリクいたします。

（バグ）
プリント時のパージの際にエクストルーダーが巻き戻ってしまうバグが生じています。

（変更内容）
gcode.py:  Coordのデフォルト値を追加
toolhead.py:  kinematicsから渡されるCoordを6軸へ変換する処理を追加
homing.py:  kinematicsから渡されるCoordを6軸へ変換する処理を追加
extras/bed_mesh.py:  ベッドメッシュが動くように最小限の6軸対応化
support_6axes.py:  3軸6軸変換ルーチン

※リジェクトをお願いいたします